### PR TITLE
Remember more than one recent tab, so that closing tabs works as expected. Fixes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,14 +25,7 @@ function getMostRecentTab(windowId) {
   let queue = recents.get(windowId);
   debug_log (`Window: ${windowId} has ${queue.length} tabs`);
   if (queue.length >= 2) {
-    let last = queue.splice(queue.length - 2, 1);
-    debug_log(last);
-    let lastId = undefined;
-    switch (last.length) {
-      case 0: debug_log("No last tab"); throw new Error ("No most recent tab"); break;
-      case 1: lastId = last[0].tabId; break;
-      default: debug_log ("Too many last tabs. This should never be reached"); throw new Error ("Unreachable code reached"); break;
-    }
+    let lastId = queue[queue.length-2].tabId;
     debug_log(`last tab id is ${lastId}`);
     return lastId;
   }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,44 @@ const DEFAULT = "Ctrl+Shift+1";
   where current is the current tab and last is the previous tab
   */
 let recents = new Map();
-const debugging = false;
+const debugging = true;
+
+function getMostRecentTab(windowId) {
+  debug_log("BEGIN getMostRecentTab");
+  if (!recents.has(windowId)) {
+    debug_log (`Nothing known about ${windowId}`);
+    return; //no info on this window to use
+  }
+
+  let oldState = recents.get(windowId);
+
+  debug_log("END getMostRecentTab");
+  return oldState.last;
+}
+
+function setMostRecentTab(windowId, tabId) {
+  // first tab for this window
+  if (!recents.has(windowId)) {
+    recents.set(windowId, {
+      last: tabId,
+      current: tabId
+    });
+    return;
+  }
+
+  // subsequent tabs
+  let oldState = recents.get(windowId);
+  let newState = {
+    last: oldState.current,
+    current: tabId
+  };
+  recents.set(windowId, newState);
+}
+
+function removeTab(windowId, tabId) {
+
+}
+
 
 function debug_log(...rest) {
   if (debugging)
@@ -30,15 +67,10 @@ function shortcutHit() {
       return;
     }
 
-    if (!recents.has(windowInfo.id)) {
-      debug_log (`Nothing known about ${windowInfo.id}`);
-      return; //no info on this window to use
-    }
+    let newTab = getMostRecentTab(windowInfo.id);
 
-    let oldState = recents.get(windowInfo.id);
-
-    debug_log("Activating tab id ", oldState.last);
-    browser.tabs.update(oldState.last,{
+    debug_log("Activating tab id ", newTab);
+    browser.tabs.update(newTab, {
       active: true
     });
 
@@ -50,22 +82,9 @@ function shortcutHit() {
 // callback when a tab is activated
 function tabActivated(newTabInfo) {
   debug_log("tabActivated(newTabInfo) begin");
-  // first tab for this window
-  if (!recents.has(newTabInfo.windowId)) {
-    recents.set(newTabInfo.windowId, {
-      last: newTabInfo.tabId,
-      current: newTabInfo.tabId
-    });
-    return;
-  }
 
-  // subsequent tabs
-  let oldState = recents.get(newTabInfo.windowId);
-  let newState = {
-    last: oldState.current,
-    current: newTabInfo.tabId
-  };
-  recents.set(newTabInfo.windowId, newState);
+  setMostRecentTab(newTabInfo.windowId, newTabInfo.tabId);
+
   debug_log("tabActivated(newTabInfo) end");
 }
 
@@ -75,7 +94,22 @@ function windowRemoved(windowId) {
   debug_log(`Window ${windowId} deleted, removing key.`);
   recents.delete(windowId);
 }
+// on window destroy, remove it from recents
+browser.windows.onRemoved.addListener(windowRemoved);
 
+// when a tab is destroyed, take it off the list
+function handleTabRemoved(tabId, removeInfo) {
+  debug_log("Tab: " + tabId + " is closing");
+  debug_log("Window ID: " + removeInfo.windowId);
+  debug_log("Window is closing: " + removeInfo.isWindowClosing);  
+
+  // if the whole window is closing, don't bother removing each element cleat it all up at once later
+  if (removeInfo.isWindowClosing) return;
+
+  remoteTab(removeInfo.windowId, tabId);
+}
+
+browser.tabs.onRemoved.addListener(handleTabRemoved);
 
 // General error handler, logs the error for debugging.
 function onError(error) {
@@ -111,9 +145,6 @@ browser.storage.onChanged.addListener(updateFromOptions);
 // hook tab change to track history
 browser.tabs.onActivated.addListener(tabActivated);
 
-// on window destroy, remove it from recents
-browser.windows.onRemoved.addListener(windowRemoved);
-
 // hook the toolbar icon
 browser.browserAction.onClicked.addListener(shortcutHit);
 
@@ -132,11 +163,7 @@ function initAWindow(windowInfoArray) {
     let tabId = activeTab[0].id;
     debug_log (`Window ${windowId} has active tab ${tabId}`);
 
-    //save this info
-    recents.set(windowId, {
-      last: tabId,
-      current: tabId
-    })
+    setMostRecentTab(windowId, tabId);
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const debugging = true;
 
 function getMostRecentTab(windowId) {
   debug_log("BEGIN getMostRecentTab");
+  debug_log(`Currently tracking ${recents.size} windows`);
   if (!recents.has(windowId)) {
     debug_log (`Nothing known about ${windowId}`);
     throw new Error("No recent tabs for this window");
@@ -87,7 +88,9 @@ function shortcutHit() {
       debug_log("Activating tab id ", newTab);
       browser.tabs.update(newTab, {
         active: true
-      });
+      }).then(() => {
+        debug_log(`Successfully switched window ${windowInfo.id} to tab ${newTab}`)
+      }, onError);
     } catch (ex) {
       debug_log(`Exception getting latest tab to activate: ${ex}`);
     }

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function getMostRecentTab(windowId) {
   let queue = recents.get(windowId);
   debug_log (`Window: ${windowId} has ${queue.length} tabs`);
   if (queue.length >= 2) {
-    let lastId = queue[queue.length-2].tabId;
+    let lastId = queue[1].tabId;
     debug_log(`last tab id is ${lastId}`);
     return lastId;
   }
@@ -50,7 +50,7 @@ function setMostRecentTab(windowId, tabId) {
   removeTab(windowId, tabId);  // <- remove it from the queue
   let queue = recents.get(windowId); // <- and add it to the top of the stack
   debug_log(`Pushing ${tabId}`);
-  queue.push({tabId: tabId});
+  queue.unshift({tabId: tabId});
   debug_log(`Success pushing ${tabId}`);
 }
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const DEFAULT = "Ctrl+Shift+1";
 let recents = new Map();
 
 //TODO: set false before shipping
-const debugging = true;
+const debugging = false;
 
 function getMostRecentTab(windowId) {
   debug_log("BEGIN getMostRecentTab");

--- a/manifest.json
+++ b/manifest.json
@@ -41,7 +41,7 @@
   "name": "Most Recent Tab",
   "author": "Paul V",
   "description": "Adds a keyboard shortcut and toolbar item to switch back to your most recently selected tab. Useful to alternate between two tabs and to easy go back to your last tab if you switch to another briefly. The shortcut is set to Control-shift-1 on Windows and Command-shift-1 on Mac. Funtionality to customize shortcuts is not yet available for WebExtensions.",
-  "version": "2.0",
+  "version": "3.0",
 
   "permissions": ["storage"]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,7 @@
 
   "browser_action": {
     "default_icon": {
-      "48": "icon.png"
+      "64": "icon.png"
     }
   },
 
@@ -33,14 +33,14 @@
   },
 
   "icons": {
-    "48": "icon.png"
+    "64": "icon.png"
   },
 
   "manifest_version": 2,
 
   "name": "Most Recent Tab",
   "author": "Paul V",
-  "description": "Adds a keyboard shortcut and toolbar item to switch back to your most recently selected tab. Useful to alternate between two tabs and to easy go back to your last tab if you switch to another briefly. The shortcut is set to Control-shift-1 on Windows and Command-shift-1 on Mac. Funtionality to customize shortcuts is not yet available for WebExtensions.",
+  "description": "Adds a keyboard shortcut and toolbar item to switch back to your most recently selected tab. Useful to alternate between two tabs and to easy go back to your last tab if you switch to another briefly. The shortcut is set to Control-shift-1 on Windows and Command-shift-1 on Mac.",
   "version": "3.0",
 
   "permissions": ["storage"]


### PR DESCRIPTION
To address bug #6, this branch adds support for remembering tab history, so that if you close tabs, it will still work. Previously closing the most recent tab would cause the shortcut to do nothing. Now it will switch to the tab before that one.

Implementation is by adding a queue for each window. Whenever a tab is activated, it's moved to the front of the queue. Activating the shortcut looks at the 2nd tab in the queue, and switches to it. Closing a tab removes it from the queue, removing it from the history. Other tabs are unaffected, so the shortcut will work as expected.